### PR TITLE
Bump version to 2.0.0-SNAPSHOT (2.x modern line)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>ips</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>ips-api</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>ips</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>ips-omod</artifactId>
@@ -17,7 +17,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>ips-api</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>2.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openmrs.web</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>ips</artifactId>
-	<version>1.0.0-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>International Patient Summary</name>
 	<description>Module that implements support for fetching, storing, and retrieving FHIR International Patient Summaries</description>


### PR DESCRIPTION
## What
Bumps the module version **`1.0.0-SNAPSHOT` → `2.0.0-SNAPSHOT`** across the root, `api`, and `omod` poms (project version, parent references, and the `ips-api` dependency).

## Why
Establishes clean, separate version lines for the two maintained branches:

| Branch | Platform | Version line |
|---|---|---|
| `main` | 2.6.0+ (modern, REST + O3 ESM) | **2.x** (`2.0.0-SNAPSHOT`) |
| `2.0.x` | 2.0.x (legacy, Jackson + server-side HTML) | **1.x** (`1.0.0`) |

So the modern module advances on the 2.x line while the legacy backport stays on 1.x.
