### PR TITLE
Omit empty sections from the rendered IPS

### DIFF
--- a/api/src/main/java/org/openmrs/module/ips/render/IpsHtmlRenderer.java
+++ b/api/src/main/java/org/openmrs/module/ips/render/IpsHtmlRenderer.java
@@ -122,12 +122,12 @@ public class IpsHtmlRenderer {
 				resources.addAll(byType.get(t));
 			}
 		}
+		// Omit sections with no data entirely rather than rendering a header + "No data available".
+		if (resources.isEmpty()) {
+			return "";
+		}
 		StringBuilder sb = new StringBuilder();
 		sb.append("<h3>").append(frTitle).append(" <span class=\"en\">/ ").append(enTitle).append("</span></h3>");
-		if (resources.isEmpty()) {
-			sb.append("<p class=\"ips-pending\">Aucune donnée disponible <span class=\"en\">/ No data available</span></p>");
-			return sb.toString();
-		}
 		sb.append("<div class=\"table-wrap\"><table class=\"ips-table\"><thead><tr>");
 		for (String c : columns) {
 			sb.append("<th>").append(c).append("</th>");


### PR DESCRIPTION
When a section (Allergies, Problems, Medications, Procedures, Diagnostic Reports, …) has no entries, the HTML renderer emitted a heading followed by "Aucune donnée disponible / No data available". This drops those sections entirely so only sections with data are shown. The underlying IPS document is unchanged (it still carries the IG-required sections with an emptyReason) — display-only change in IpsHtmlRenderer.section().