### PR TITLE
Fetch by SEDISH source-key with a wrong-patient guard + per-type/site renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,29 @@ To set up the IPS module, configure the following global properties in your Open
 
 | Property             | Description                                                                                                   |
 |----------------------|---------------------------------------------------------------------------------------------------------------|
-| `ips.url`            | Base URL of the IPS source that returns the consolidated IPS bundle (e.g. an SHR / OpenHIM IPS mediator). The per-patient path (`/Patient/<identifierType>/<id>`) is appended at fetch time. |
+| `ips.url`            | Base URL of the IPS source that returns the consolidated IPS bundle (e.g. an SHR / OpenHIM IPS mediator). The per-patient path is appended at fetch time (see lookup below). |
 | `ips.concept`        | UUID of the **complex** concept used to store the fetched IPS bundle.                                          |
-| `ips.identifierType` | Name **or** UUID of the patient identifier type whose value is sent to the IPS source (e.g. `iSantePlus ID`). |
+| `ips.identifierType` | Name **or** UUID of the patient identifier type whose value is sent to the IPS source (e.g. `iSantePlus ID`). Only used for the legacy fallback lookup. |
 | `ips.username`       | Basic-auth username for the IPS source / OpenHIM channel (blank = no auth header).                             |
 | `ips.password`       | Basic-auth password for the IPS source / OpenHIM channel (blank = no auth header).                            |
+| `mpi-client.source.mspp` | (shared with the mpi-client module) The site's MSPP facility code. **Set it** — it switches the lookup to the unambiguous source-key path. |
+| `mpi-client.source.keySystem` | (shared with the mpi-client module) FHIR system of the SEDISH source-key. Default `http://sedish-haiti.org/fhir/source-key`. |
+
+### Patient lookup: source-key first (wrong-patient guard)
+
+iSantePlus IDs are issued **per facility** and are NOT nationally unique — the same value can belong
+to different people at different sites, so fetching by iSantePlus ID alone can return **another
+patient's summary**. Therefore:
+
+- When `mpi-client.source.mspp` is set, the module fetches by **SEDISH source-key**
+  (`<mspp_code>-<patient_id>`, the same key the mpi-client module stamps on every record exported to
+  OpenCR): `GET <ips.url>/Patient/source-key/<mspp>-<patient_id>`. The mediator must expose this
+  route (shared-health-record ≥ the source-key patch).
+- When it is not set, the legacy `GET <ips.url>/Patient/isanteplus/<iSantePlus ID>` lookup is used.
+- In **both** cases a guard verifies the returned bundle's Patient really is the local patient
+  (source-key identifier match, else birth date + family name). A non-matching bundle is never
+  stored and never shown — the UI gets a bilingual notice instead. A previously stored bundle that
+  fails the guard is ignored and refetched.
 
 > Note: this `1.x` (legacy) branch differs from the modern module — it uses `ips.identifierType`
 > (name or UUID), not `ips.identifierType.uuid`, and adds `ips.username` / `ips.password` for a

--- a/api/src/main/java/org/openmrs/module/ips/InternationalPatientSummaryConstants.java
+++ b/api/src/main/java/org/openmrs/module/ips/InternationalPatientSummaryConstants.java
@@ -40,4 +40,16 @@ public final class InternationalPatientSummaryConstants {
 	public static final String IPS_PASSWORD = "ips.password";
 
 	public static final String DEFAULT_IDENTIFIER_TYPE = "iSantePlus ID";
+
+	/**
+	 * GP shared with the mpi-client module: the site's MSPP facility code. When set, the IPS is
+	 * fetched by SEDISH source-key ({@code <mspp>-<patient_id>}) instead of the nationally
+	 * NON-unique iSantePlus ID, which can otherwise return another patient's summary.
+	 */
+	public static final String MPI_MSPP_CODE = "mpi-client.source.mspp";
+
+	/** GP shared with the mpi-client module: FHIR system of the SEDISH source-key identifier. */
+	public static final String MPI_SOURCE_KEY_SYSTEM = "mpi-client.source.keySystem";
+
+	public static final String DEFAULT_SOURCE_KEY_SYSTEM = "http://sedish-haiti.org/fhir/source-key";
 }

--- a/api/src/main/java/org/openmrs/module/ips/api/impl/InternationalPatientSummaryServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/ips/api/impl/InternationalPatientSummaryServiceImpl.java
@@ -15,6 +15,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -37,6 +38,8 @@ import org.openmrs.api.db.ClobDatatypeStorage;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.ips.InternationalPatientSummaryConstants;
 import org.openmrs.module.ips.api.InternationalPatientSummaryService;
+import org.openmrs.module.ips.fetch.IpsPatientMatcher;
+import org.openmrs.module.ips.fetch.SourceKey;
 import org.openmrs.module.ips.render.IpsHtmlRenderer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,28 +72,66 @@ public class InternationalPatientSummaryServiceImpl extends BaseOpenmrsService i
 
 	@Override
 	public String fetchAndStoreIps(Patient patient) throws Exception {
-		String identifier = getConfiguredIdentifier(patient);
-		if (identifier == null) {
-			log.warn("Patient {} has no '{}' identifier; cannot fetch IPS", patient.getUuid(),
-			    getIdentifierTypeSetting());
+
+		String sourceKey = buildLocalSourceKey(patient);
+		String identifier = sourceKey == null ? getConfiguredIdentifier(patient) : null;
+
+		if (sourceKey == null && identifier == null) {
+			log.warn("Patient " + patient.getUuid() + " has no source-key (GP '"
+			        + InternationalPatientSummaryConstants.MPI_MSPP_CODE + "') and no '" + getIdentifierTypeSetting()
+			        + "' identifier; cannot fetch IPS");
 			return null;
 		}
 
+		FetchOutcome outcome = doFetchAndStore(patient, sourceKey, identifier);
+		return outcome.mismatch ? null : outcome.json;
+	}
+
+	/**
+	 * Fetches from the mediator — by SEDISH source-key when the site's MSPP code is configured
+	 * (iSantePlus IDs are not nationally unique), else by iSantePlus ID — then verifies the returned
+	 * bundle really belongs to this patient before storing it. A non-matching bundle is NEVER stored.
+	 */
+	private FetchOutcome doFetchAndStore(Patient patient, String sourceKey, String identifier) throws Exception {
 		String base = administrationService.getGlobalProperty(InternationalPatientSummaryConstants.IPS_URL);
 		if (isBlank(base)) {
 			throw new IllegalStateException("Global property '" + InternationalPatientSummaryConstants.IPS_URL
 			        + "' is not set");
 		}
-		String url = stripTrailingSlash(base) + "/Patient/isanteplus/" + identifier;
+		if (sourceKey == null) {
+			log.warn("GP '" + InternationalPatientSummaryConstants.MPI_MSPP_CODE
+			        + "' is not set; falling back to the ambiguous iSantePlus-ID lookup for patient "
+			        + patient.getUuid());
+		}
+		String url = SourceKey.buildFetchUrl(base, sourceKey, identifier);
 
 		String json = httpGet(url);
 		if (isBlank(json)) {
 			log.warn("Mediator returned an empty IPS for patient {}", patient.getUuid());
-			return null;
+			return new FetchOutcome(null, false);
+		}
+
+		if (!isLocalPatient(patient, json)) {
+			log.warn("IPS returned by the mediator does NOT match patient " + patient.getUuid()
+			        + " (source-key/demographics check failed); discarding it — not stored, not shown");
+			return new FetchOutcome(null, true);
 		}
 
 		storeIps(patient, json);
-		return json;
+		return new FetchOutcome(json, false);
+	}
+
+	private static final class FetchOutcome {
+
+		final String json;
+
+		/** true when the mediator returned a bundle that belongs to ANOTHER patient. */
+		final boolean mismatch;
+
+		FetchOutcome(String json, boolean mismatch) {
+			this.json = json;
+			this.mismatch = mismatch;
+		}
 	}
 
 	@Override
@@ -113,7 +154,7 @@ public class InternationalPatientSummaryServiceImpl extends BaseOpenmrsService i
 	@Override
 	public String getOrFetchIps(Patient patient) throws Exception {
 		String stored = getStoredIps(patient);
-		if (!isBlank(stored)) {
+		if (!isBlank(stored) && isLocalPatient(patient, stored)) {
 			return stored;
 		}
 		return fetchAndStoreIps(patient);
@@ -140,23 +181,37 @@ public class InternationalPatientSummaryServiceImpl extends BaseOpenmrsService i
 		try {
 			String stored = getStoredIps(patient);
 			if (!isBlank(stored)) {
-				return renderer.render(stored);
+				if (isLocalPatient(patient, stored)) {
+					return renderer.render(stored);
+				}
+				// A copy stored before the source-key fix may belong to another patient with the
+				// same iSantePlus ID: never show it, try a fresh (verified) fetch instead.
+				log.warn("Stored IPS for patient " + patient.getUuid()
+				        + " does not match the patient; ignoring it and refetching");
 			}
-			String identifier = getConfiguredIdentifier(patient);
-			if (identifier == null) {
+
+			String sourceKey = buildLocalSourceKey(patient);
+			String identifier = sourceKey == null ? getConfiguredIdentifier(patient) : null;
+			if (sourceKey == null && identifier == null) {
 				String type = getIdentifierTypeSetting();
-				log.warn("Patient " + patient.getUuid() + " has no '" + type + "' identifier; cannot fetch IPS");
 				return renderer.renderNotice(
-				    "Ce patient n'a pas d'identifiant « " + type + " », requis pour récupérer le résumé.",
-				    "This patient has no '" + type + "' identifier, required to fetch the summary.");
+				    "Ce patient n'a pas d'identifiant « " + type + " » (et le code MSPP du site n'est pas configuré), requis pour récupérer le résumé.",
+				    "This patient has no '" + type + "' identifier (and the site's MSPP code is not configured), required to fetch the summary.");
 			}
-			String json = fetchAndStoreIps(patient);
-			if (isBlank(json)) {
+
+			FetchOutcome outcome = doFetchAndStore(patient, sourceKey, identifier);
+			if (outcome.mismatch) {
 				return renderer.renderNotice(
-				    "Aucun résumé renvoyé par le SHR pour l'identifiant " + identifier + ".",
-				    "No summary returned by the SHR for identifier " + identifier + ".");
+				    "Le résumé renvoyé par le SHR ne correspond pas à ce patient (identifiant partagé entre plusieurs sites) — affichage bloqué par sécurité.",
+				    "The summary returned by the SHR does not match this patient (identifier shared across sites) — display blocked for safety.");
 			}
-			return renderer.render(json);
+			if (isBlank(outcome.json)) {
+				String lookup = sourceKey != null ? sourceKey : identifier;
+				return renderer.renderNotice(
+				    "Aucun résumé renvoyé par le SHR pour l'identifiant " + lookup + ".",
+				    "No summary returned by the SHR for identifier " + lookup + ".");
+			}
+			return renderer.render(outcome.json);
 		}
 		catch (Exception e) {
 			log.error("Error building IPS HTML for patient " + patient.getUuid(), e);
@@ -225,6 +280,30 @@ public class InternationalPatientSummaryServiceImpl extends BaseOpenmrsService i
 			return null;
 		}
 		return conceptService.getConceptByUuid(ref);
+	}
+
+	/**
+	 * @return this patient's SEDISH source-key ({@code <mspp>-<patient_id>}), or {@code null} when
+	 *         the site's MSPP code (GP shared with mpi-client) is not configured.
+	 */
+	private String buildLocalSourceKey(Patient patient) {
+		String mspp = administrationService.getGlobalProperty(InternationalPatientSummaryConstants.MPI_MSPP_CODE);
+		return SourceKey.build(mspp, patient.getPatientId());
+	}
+
+	private String getSourceKeySystem() {
+		String system = administrationService
+		        .getGlobalProperty(InternationalPatientSummaryConstants.MPI_SOURCE_KEY_SYSTEM);
+		return isBlank(system) ? InternationalPatientSummaryConstants.DEFAULT_SOURCE_KEY_SYSTEM : system;
+	}
+
+	/** @return whether the bundle's Patient resource really is this patient (never trust a bare-ID match). */
+	private boolean isLocalPatient(Patient patient, String bundleJson) {
+		String birthDate = patient.getBirthdate() != null
+		        ? new SimpleDateFormat("yyyy-MM-dd").format(patient.getBirthdate())
+		        : null;
+		return IpsPatientMatcher.matches(bundleJson, getSourceKeySystem(), buildLocalSourceKey(patient), birthDate,
+		    patient.getFamilyName());
 	}
 
 	private String getIdentifierTypeSetting() {
@@ -321,10 +400,6 @@ public class InternationalPatientSummaryServiceImpl extends BaseOpenmrsService i
 			}
 		}
 		return sb.toString();
-	}
-
-	private String stripTrailingSlash(String s) {
-		return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
 	}
 
 	private static boolean isBlank(String s) {

--- a/api/src/main/java/org/openmrs/module/ips/fetch/IpsPatientMatcher.java
+++ b/api/src/main/java/org/openmrs/module/ips/fetch/IpsPatientMatcher.java
@@ -1,0 +1,87 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.ips.fetch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Guard against the wrong-patient hazard of non-unique iSantePlus IDs: verifies that the Patient
+ * resource inside a fetched IPS bundle really is the local patient before the summary is stored or
+ * shown.
+ *
+ * <p>
+ * A cross-facility bundle carries several Patient resources (the golden record plus every linked
+ * source record). The bundle is accepted when ANY of them carries the local patient's SEDISH
+ * source-key identifier, or — the golden record may not list our site's source-key — when both the
+ * birth date and the family name match. Anything else (including a bundle with no Patient resource,
+ * or unparseable JSON) is rejected.
+ * </p>
+ */
+public final class IpsPatientMatcher {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
+	private IpsPatientMatcher() {
+	}
+
+	public static boolean matches(String bundleJson, String sourceKeySystem, String expectedSourceKey,
+	        String expectedBirthDate, String expectedFamilyName) {
+		try {
+			// A cross-facility bundle carries the golden record AND every linked source record, in
+			// arbitrary order — the local patient's own record may not come first. Accept as soon
+			// as ANY of them matches; reject only when none does.
+			for (JsonNode entry : MAPPER.readTree(bundleJson).path("entry")) {
+				// SEDISH bundles carry entries as bare resources; standard FHIR wraps them in "resource"
+				JsonNode resource = entry.has("resourceType") ? entry : entry.path("resource");
+				if (!"Patient".equals(resource.path("resourceType").asText())) {
+					continue;
+				}
+				if (hasSourceKey(resource, sourceKeySystem, expectedSourceKey)
+				        || matchesDemographics(resource, expectedBirthDate, expectedFamilyName)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		catch (Exception e) {
+			return false;
+		}
+	}
+
+	private static boolean hasSourceKey(JsonNode patient, String system, String expectedValue) {
+		if (system == null || expectedValue == null) {
+			return false;
+		}
+		for (JsonNode identifier : patient.path("identifier")) {
+			if (system.equals(identifier.path("system").asText())
+			        && expectedValue.equals(identifier.path("value").asText())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private static boolean matchesDemographics(JsonNode patient, String expectedBirthDate, String expectedFamilyName) {
+		if (expectedBirthDate == null || expectedFamilyName == null) {
+			return false;
+		}
+		if (!expectedBirthDate.equals(patient.path("birthDate").asText())) {
+			return false;
+		}
+		for (JsonNode name : patient.path("name")) {
+			String family = name.path("family").asText();
+			if (expectedFamilyName.trim().equalsIgnoreCase(family.trim())) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/ips/fetch/SourceKey.java
+++ b/api/src/main/java/org/openmrs/module/ips/fetch/SourceKey.java
@@ -1,0 +1,49 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.ips.fetch;
+
+/**
+ * Builds the SEDISH source-key ({@code <mspp_code>-<patient_id>}) and the mediator fetch URL.
+ *
+ * <p>
+ * iSantePlus IDs are issued per facility and are NOT nationally unique — the same value can belong
+ * to different people at different sites, so fetching by iSantePlus ID alone can return another
+ * patient's summary. The source-key (also stamped on every record exported to OpenCR by the
+ * mpi-client module) is nationally unique and resolves to exactly this patient.
+ * </p>
+ */
+public final class SourceKey {
+
+	private SourceKey() {
+	}
+
+	/**
+	 * @return {@code <msppCode>-<patientId>} (e.g. {@code 54111-35}), or {@code null} when either
+	 *         part is missing — callers then fall back to the legacy iSantePlus-ID lookup.
+	 */
+	public static String build(String msppCode, Integer patientId) {
+		if (msppCode == null || msppCode.trim().isEmpty() || patientId == null) {
+			return null;
+		}
+		return msppCode.trim() + "-" + patientId;
+	}
+
+	/**
+	 * @return the mediator URL to fetch the IPS from: {@code <base>/Patient/source-key/<key>} when a
+	 *         source-key is available, else the legacy {@code <base>/Patient/isanteplus/<id>}.
+	 */
+	public static String buildFetchUrl(String baseUrl, String sourceKey, String isantePlusId) {
+		String base = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+		if (sourceKey != null) {
+			return base + "/Patient/source-key/" + sourceKey;
+		}
+		return base + "/Patient/isanteplus/" + isantePlusId;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/ips/render/IpsHtmlRenderer.java
+++ b/api/src/main/java/org/openmrs/module/ips/render/IpsHtmlRenderer.java
@@ -10,9 +10,14 @@
 package org.openmrs.module.ips.render;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -21,13 +26,14 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Renders a FHIR IPS {@code Bundle} JSON string into a self-contained, bilingual (FR/EN) HTML
- * fragment for the legacy UI.
+ * fragment for the legacy UI. No HAPI/Groovy — the bundle is walked with Jackson.
  *
  * <p>
- * The layout mirrors the OpenMRS 3.x IPS ESM (DIGI-UW/openmrs-esm-ips): per-section structured
- * columns and colored status tags (red = critical/active/severe, green = completed/normal,
- * blue = other), so the legacy render matches how the IPS shows in O3. No HAPI/Groovy — the bundle
- * is walked with Jackson.
+ * The bundle aggregates data from several facilities (cross-facility golden-record summary), so
+ * every clinical row shows its facility of origin (the {@code mspp-site} meta tag). Technical
+ * noise is filtered out (registration/visit-container encounters, source-key and UUID
+ * identifiers, raw category codes, nominal status pills), dates render as DD/MM/YYYY, rows sort
+ * newest-first, and date-valued observations, medication reasons and humanized dosages are shown.
  * </p>
  */
 public class IpsHtmlRenderer {
@@ -36,7 +42,13 @@ public class IpsHtmlRenderer {
 
 	private static final String DASH = "--";
 
+	private static final String MSPP_SITE_TAG_SYSTEM = "mspp-site";
+
+	private static final Pattern UUID_VALUE = Pattern
+	        .compile("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
 	public String render(String bundleJson) {
+
 		StringBuilder sb = new StringBuilder();
 		sb.append(styleBlock());
 		sb.append("<div class=\"ips-card\">");
@@ -59,6 +71,7 @@ public class IpsHtmlRenderer {
 		}
 
 		Map<String, List<JsonNode>> byType = new LinkedHashMap<String, List<JsonNode>>();
+		Set<String> sites = new LinkedHashSet<String>();
 		JsonNode entries = bundle.path("entry");
 		if (entries.isArray()) {
 			for (JsonNode entry : entries) {
@@ -71,61 +84,203 @@ public class IpsHtmlRenderer {
 					byType.put(type, new ArrayList<JsonNode>());
 				}
 				byType.get(type).add(r);
+				String site = siteOf(r);
+				if (!site.isEmpty()) {
+					sites.add(site);
+				}
 			}
 		}
 
 		sb.append(title());
-		sb.append(header(byType.get("Patient")));
+		sb.append(header(byType.get("Patient"), sites));
 
-		sb.append(section("Allergies et intolérances", "Allergies &amp; Intolerances", byType,
-		    new String[] { "AllergyIntolerance" },
-		    new String[] { "Catégorie / Category", "Criticité / Criticality", "Description" }, Kind.ALLERGY));
-		sb.append(section("Problèmes", "Problems", byType,
-		    new String[] { "Condition" },
-		    new String[] { "Nom / Name", "Statut clinique / Clinical Status", "Sévérité / Severity", "Catégorie / Category" },
-		    Kind.CONDITION));
-		sb.append(section("Médicaments", "Medications", byType,
-		    new String[] { "MedicationStatement", "MedicationRequest" },
-		    new String[] { "Médicament / Medication", "Voie / Route", "Posologie / Dosage", "Statut / Status", "Date" },
-		    Kind.MEDICATION));
-		sb.append(section("Vaccinations", "Immunizations", byType,
-		    new String[] { "Immunization" },
-		    new String[] { "Date", "Statut / Status", "Vaccin / Vaccine", "Voie / Route" }, Kind.IMMUNIZATION));
-		sb.append(section("Résultats et observations", "Results &amp; Observations", byType,
-		    new String[] { "Observation" },
-		    new String[] { "Nom / Name", "Date", "Valeur / Value", "Catégorie / Category" }, Kind.OBSERVATION));
-		sb.append(section("Actes", "Procedures", byType,
-		    new String[] { "Procedure" },
-		    new String[] { "Acte / Procedure", "Statut / Status", "Date" }, Kind.PROCEDURE));
-		sb.append(section("Comptes rendus", "Diagnostic Reports", byType,
-		    new String[] { "DiagnosticReport" },
-		    new String[] { "Compte rendu / Report", "Statut / Status", "Date" }, Kind.DIAGNOSTIC));
-		sb.append(section("Consultations", "Encounters", byType,
-		    new String[] { "Encounter" },
-		    new String[] { "Type", "Statut / Status", "Date" }, Kind.ENCOUNTER));
+		sb.append(section("Allergies et intolérances", "Allergies &amp; Intolerances",
+		    new String[] { "Description", "Criticité / Criticality", "Site" },
+		    allergyRows(resources(byType, "AllergyIntolerance"))));
+		sb.append(section("Problèmes", "Problems",
+		    new String[] { "Nom / Name", "Statut clinique / Clinical Status", "Sévérité / Severity", "Site" },
+		    conditionRows(resources(byType, "Condition"))));
+		sb.append(section("Médicaments", "Medications",
+		    new String[] { "Médicament / Medication", "Posologie / Dosage", "Motif / Reason", "Statut / Status", "Date",
+		            "Site" },
+		    medicationRows(resources(byType, "MedicationStatement", "MedicationRequest"))));
+		sb.append(section("Vaccinations", "Immunizations",
+		    new String[] { "Vaccin / Vaccine", "Date", "Statut / Status", "Site" },
+		    immunizationRows(resources(byType, "Immunization"))));
+		sb.append(section("Résultats et observations", "Results &amp; Observations",
+		    new String[] { "Nom / Name", "Valeur / Value", "Date", "Site" },
+		    observationRows(resources(byType, "Observation"))));
+		sb.append(section("Actes", "Procedures",
+		    new String[] { "Acte / Procedure", "Statut / Status", "Date", "Site" },
+		    procedureRows(resources(byType, "Procedure"))));
+		sb.append(section("Comptes rendus", "Diagnostic Reports",
+		    new String[] { "Compte rendu / Report", "Statut / Status", "Date", "Site" },
+		    diagnosticRows(resources(byType, "DiagnosticReport"))));
+		sb.append(section("Consultations", "Encounters",
+		    new String[] { "Type", "Statut / Status", "Date", "Site" },
+		    encounterRows(resources(byType, "Encounter"))));
 
 		sb.append("</div>");
+
 		return sb.toString();
 	}
 
-	private enum Kind {
-		ALLERGY, CONDITION, MEDICATION, IMMUNIZATION, OBSERVATION, PROCEDURE, DIAGNOSTIC, ENCOUNTER
+	// --- rows ------------------------------------------------------------------------------------
+
+	/** One rendered table row: HTML-ready cells plus the raw ISO date used for newest-first sorting. */
+	private static final class Row {
+
+		final String[] cells;
+
+		final String sortDate;
+
+		Row(String sortDate, String... cells) {
+			this.sortDate = sortDate == null ? "" : sortDate;
+			this.cells = cells;
+		}
+	}
+
+	private List<JsonNode> resources(Map<String, List<JsonNode>> byType, String... types) {
+		List<JsonNode> out = new ArrayList<JsonNode>();
+		for (String t : types) {
+			if (byType.containsKey(t)) {
+				out.addAll(byType.get(t));
+			}
+		}
+		return out;
+	}
+
+	private List<Row> allergyRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			String crit = r.path("criticality").asText("");
+			String critCell = crit.isEmpty() ? DASH
+			        : tag(crit, crit.equalsIgnoreCase("high") ? "red" : crit.equalsIgnoreCase("low") ? "green" : "blue");
+			rows.add(new Row(r.path("recordedDate").asText(""), txt(codeable(r.path("code"))), critCell, siteCell(r)));
+		}
+		return rows;
+	}
+
+	private List<Row> conditionRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			String clin = codingCode(r.path("clinicalStatus"));
+			String sev = codeable(r.path("severity"));
+			String clinCell = clin.isEmpty() ? DASH : tag(clin, clin.toLowerCase().contains("active") ? "red" : "green");
+			String sevCell = sev.isEmpty() ? DASH : tag(sev, sev.toLowerCase().contains("severe") ? "red" : "blue");
+			rows.add(new Row(firstNonEmpty(r.path("onsetDateTime").asText(""), r.path("recordedDate").asText("")),
+			        txt(codeable(r.path("code"))), clinCell, sevCell, siteCell(r)));
+		}
+		return rows;
+	}
+
+	private List<Row> medicationRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			String date = firstNonEmpty(r.path("effectiveDateTime").asText(""),
+			    r.path("effectivePeriod").path("start").asText(""), r.path("authoredOn").asText(""));
+			String status = r.path("status").asText("");
+			// medications always show their status — "active" is clinically significant
+			String statusCell = status.isEmpty() ? DASH
+			        : tag(status, status.equalsIgnoreCase("active") || status.equalsIgnoreCase("completed") ? "green"
+			                : "blue");
+			rows.add(new Row(date, txt(codeable(bestNode(r, "medicationCodeableConcept", "medication"))),
+			        txt(dosageSummary(r)), txt(reason(r)), statusCell, txt(dateFr(date)), siteCell(r)));
+		}
+		return rows;
+	}
+
+	private List<Row> immunizationRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			String date = r.path("occurrenceDateTime").asText("");
+			rows.add(new Row(date, txt(codeable(r.path("vaccineCode"))), txt(dateFr(date)),
+			        statusCell(r.path("status").asText(""), "completed"), siteCell(r)));
+		}
+		return rows;
+	}
+
+	private List<Row> observationRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			String date = firstNonEmpty(r.path("effectiveDateTime").asText(""),
+			    r.path("effectivePeriod").path("start").asText(""), r.path("issued").asText(""));
+			rows.add(new Row(date, txt(codeable(r.path("code"))), txt(observationValue(r)), txt(dateFr(date)),
+			        siteCell(r)));
+		}
+		return rows;
+	}
+
+	private List<Row> procedureRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			String date = firstNonEmpty(r.path("performedDateTime").asText(""),
+			    r.path("performedPeriod").path("start").asText(""));
+			rows.add(new Row(date, txt(codeable(r.path("code"))), statusCell(r.path("status").asText(""), "completed"),
+			        txt(dateFr(date)), siteCell(r)));
+		}
+		return rows;
+	}
+
+	private List<Row> diagnosticRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			String date = firstNonEmpty(r.path("effectiveDateTime").asText(""), r.path("issued").asText(""));
+			rows.add(new Row(date, txt(codeable(r.path("code"))), statusCell(r.path("status").asText(""), "final"),
+			        txt(dateFr(date)), siteCell(r)));
+		}
+		return rows;
+	}
+
+	private List<Row> encounterRows(List<JsonNode> resources) {
+		List<Row> rows = new ArrayList<Row>();
+		for (JsonNode r : resources) {
+			if (skipEncounter(r)) {
+				continue;
+			}
+			String date = r.path("period").path("start").asText("");
+			rows.add(new Row(date, txt(encounterType(r)), statusCell(r.path("status").asText(""), "finished"),
+			        txt(dateFr(date)), siteCell(r)));
+		}
+		return rows;
+	}
+
+	/**
+	 * Administrative noise: registration encounters, visit-container encounters (tagged
+	 * {@code encounter-tag=visit}) and untyped encounters that are not even finished carry no
+	 * clinical information — drop them.
+	 */
+	private boolean skipEncounter(JsonNode r) {
+		String type = encounterTypeText(r);
+		if (type.equalsIgnoreCase("Enregistrement de patient")) {
+			return true;
+		}
+		for (JsonNode t : r.path("meta").path("tag")) {
+			if (t.path("system").asText("").contains("encounter-tag") && t.path("code").asText("").equals("visit")) {
+				return true;
+			}
+		}
+		return type.isEmpty() && !r.path("status").asText("").equalsIgnoreCase("finished");
 	}
 
 	// --- section rendering -----------------------------------------------------------------------
 
-	private String section(String frTitle, String enTitle, Map<String, List<JsonNode>> byType, String[] types,
-	        String[] columns, Kind kind) {
-		List<JsonNode> resources = new ArrayList<JsonNode>();
-		for (String t : types) {
-			if (byType.containsKey(t)) {
-				resources.addAll(byType.get(t));
-			}
-		}
+	private String section(String frTitle, String enTitle, String[] columns, List<Row> rows) {
 		// Omit sections with no data entirely rather than rendering a header + "No data available".
-		if (resources.isEmpty()) {
+		if (rows.isEmpty()) {
 			return "";
 		}
+		// newest first, undated rows last (ISO dates compare lexicographically)
+		Collections.sort(rows, new Comparator<Row>() {
+
+			@Override
+			public int compare(Row a, Row b) {
+				if (a.sortDate.isEmpty() || b.sortDate.isEmpty()) {
+					return a.sortDate.isEmpty() ? (b.sortDate.isEmpty() ? 0 : 1) : -1;
+				}
+				return b.sortDate.compareTo(a.sortDate);
+			}
+		});
 		StringBuilder sb = new StringBuilder();
 		sb.append("<h3>").append(frTitle).append(" <span class=\"en\">/ ").append(enTitle).append("</span></h3>");
 		sb.append("<div class=\"table-wrap\"><table class=\"ips-table\"><thead><tr>");
@@ -133,9 +288,9 @@ public class IpsHtmlRenderer {
 			sb.append("<th>").append(c).append("</th>");
 		}
 		sb.append("</tr></thead><tbody>");
-		for (JsonNode r : resources) {
+		for (Row row : rows) {
 			sb.append("<tr>");
-			for (String cell : cellsFor(kind, r)) {   // cells are already HTML-ready
+			for (String cell : row.cells) {   // cells are already HTML-ready
 				sb.append("<td>").append(cell).append("</td>");
 			}
 			sb.append("</tr>");
@@ -144,72 +299,9 @@ public class IpsHtmlRenderer {
 		return sb.toString();
 	}
 
-	/** Per-type cells, mirroring the O3 ESM templates (columns + colored tags). Cells are HTML. */
-	private String[] cellsFor(Kind kind, JsonNode r) {
-		switch (kind) {
-			case ALLERGY: {
-				String crit = r.path("criticality").asText("");
-				String color = crit.equalsIgnoreCase("high") ? "red"
-				        : (!crit.isEmpty() && !crit.equalsIgnoreCase("normal")) ? "blue" : "green";
-				return new String[] { txt(categoryText(r.path("category"))),
-				        tag(crit.isEmpty() ? "Unknown" : crit, color), txt(codeable(r.path("code"))) };
-			}
-			case CONDITION: {
-				String clin = codingCode(r.path("clinicalStatus"));
-				String sev = codeable(r.path("severity"));
-				String clinColor = clin.toLowerCase().contains("active") ? "red" : "green";
-				String sevColor = sev.toLowerCase().contains("severe") ? "red" : "blue";
-				return new String[] { txt(codeable(r.path("code"))),
-				        tag(clin.isEmpty() ? "Unknown" : clin, clinColor),
-				        sev.isEmpty() ? DASH : tag(sev, sevColor), txt(categoryText(r.path("category"))) };
-			}
-			case MEDICATION: {
-				String status = r.path("status").asText("");
-				String date = firstNonEmpty(r.path("effectiveDateTime").asText(""),
-				    r.path("effectivePeriod").path("start").asText(""), r.path("authoredOn").asText(""));
-				return new String[] { txt(codeable(bestNode(r, "medicationCodeableConcept", "medication"))),
-				        txt(dosageRoute(r)), txt(dosageText(r)),
-				        status.isEmpty() ? DASH : tag(status, status.equalsIgnoreCase("active") || status.equalsIgnoreCase("completed") ? "green" : "blue"),
-				        txt(dateShort(date)) };
-			}
-			case IMMUNIZATION: {
-				String status = r.path("status").asText("");
-				return new String[] { txt(dateShort(r.path("occurrenceDateTime").asText(""))),
-				        status.isEmpty() ? DASH : tag(status, status.equalsIgnoreCase("completed") ? "green" : "blue"),
-				        txt(codeable(r.path("vaccineCode"))), txt(codeable(r.path("route"))) };
-			}
-			case OBSERVATION:
-				return new String[] { txt(codeable(r.path("code"))),
-				        txt(dateShort(firstNonEmpty(r.path("effectiveDateTime").asText(""),
-				            r.path("effectivePeriod").path("start").asText(""), r.path("issued").asText("")))),
-				        txt(observationValue(r)), txt(categoryText(r.path("category"))) };
-			case PROCEDURE: {
-				String status = r.path("status").asText("");
-				return new String[] { txt(codeable(r.path("code"))),
-				        status.isEmpty() ? DASH : tag(status, status.equalsIgnoreCase("completed") ? "green" : "blue"),
-				        txt(dateShort(firstNonEmpty(r.path("performedDateTime").asText(""),
-				            r.path("performedPeriod").path("start").asText("")))) };
-			}
-			case DIAGNOSTIC: {
-				String status = r.path("status").asText("");
-				return new String[] { txt(codeable(r.path("code"))),
-				        status.isEmpty() ? DASH : tag(status, status.equalsIgnoreCase("final") ? "green" : "blue"),
-				        txt(dateShort(firstNonEmpty(r.path("effectiveDateTime").asText(""), r.path("issued").asText("")))) };
-			}
-			case ENCOUNTER: {
-				String status = r.path("status").asText("");
-				return new String[] { txt(encounterType(r)),
-				        status.isEmpty() ? DASH : tag(status, status.equalsIgnoreCase("finished") ? "green" : "blue"),
-				        txt(dateShort(r.path("period").path("start").asText(""))) };
-			}
-			default:
-				return new String[] { DASH };
-		}
-	}
-
 	// --- patient header --------------------------------------------------------------------------
 
-	private String header(List<JsonNode> patients) {
+	private String header(List<JsonNode> patients, Set<String> sites) {
 		if (patients == null || patients.isEmpty()) {
 			return "";
 		}
@@ -226,7 +318,7 @@ public class IpsHtmlRenderer {
 			if (sub.length() > 0) {
 				sub.append(" &middot; ");
 			}
-			sub.append(esc(birth));
+			sub.append(esc(dateFr(birth)));
 		}
 		if (sub.length() > 0) {
 			sb.append("<p class=\"ips-sub\">").append(sub).append("</p>");
@@ -236,7 +328,7 @@ public class IpsHtmlRenderer {
 			sb.append("<div class=\"ips-ids\">");
 			for (JsonNode id : ids) {
 				String value = id.path("value").asText("");
-				if (value.isEmpty()) {
+				if (value.isEmpty() || isTechnicalIdentifier(id, value)) {
 					continue;
 				}
 				String label = id.path("type").path("text").asText("");
@@ -248,10 +340,56 @@ public class IpsHtmlRenderer {
 			}
 			sb.append("</div>");
 		}
+		if (!sites.isEmpty()) {
+			StringBuilder list = new StringBuilder();
+			for (String s : sites) {
+				if (list.length() > 0) {
+					list.append(", ");
+				}
+				list.append(esc(s));
+			}
+			sb.append("<p class=\"ips-sites\">Sites : ").append(list).append("</p>");
+		}
 		return sb.toString();
 	}
 
+	/** Source-keys and UUID-valued identifiers are plumbing, not clinical identity — hide them. */
+	private boolean isTechnicalIdentifier(JsonNode id, String value) {
+		if (UUID_VALUE.matcher(value).matches()) {
+			return true;
+		}
+		String typeText = id.path("type").path("text").asText("");
+		if (typeText.equalsIgnoreCase("SEDISH Source Key")) {
+			return true;
+		}
+		return id.path("system").asText("").contains("source-key");
+	}
+
 	// --- FHIR field helpers ----------------------------------------------------------------------
+
+	/** The facility of origin, from the resource's mspp-site meta tag (name, else MSPP code). */
+	private String siteOf(JsonNode r) {
+		for (JsonNode t : r.path("meta").path("tag")) {
+			if (t.path("system").asText("").contains(MSPP_SITE_TAG_SYSTEM)) {
+				String display = t.path("display").asText("");
+				return !display.isEmpty() ? display : t.path("code").asText("");
+			}
+		}
+		return "";
+	}
+
+	private String siteCell(JsonNode r) {
+		String site = siteOf(r);
+		return site.isEmpty() ? DASH : "<span class=\"ips-site\">" + esc(site) + "</span>";
+	}
+
+	/** A status pill only when it informs: the nominal status renders as an empty cell. */
+	private String statusCell(String status, String nominal) {
+		if (status.isEmpty() || status.equalsIgnoreCase(nominal)) {
+			return "";
+		}
+		return tag(status, "blue");
+	}
 
 	private String humanName(JsonNode patient) {
 		JsonNode names = patient.path("name");
@@ -305,25 +443,6 @@ public class IpsHtmlRenderer {
 		return "";
 	}
 
-	/** category may be an array of strings (AllergyIntolerance) or of CodeableConcept (Condition/Observation). */
-	private String categoryText(JsonNode cat) {
-		if (cat == null || !cat.isArray() || cat.size() == 0) {
-			return "";
-		}
-		StringBuilder sb = new StringBuilder();
-		for (JsonNode item : cat) {
-			String v = item.isTextual() ? item.asText("") : codeable(item);
-			if (v == null || v.isEmpty()) {
-				continue;
-			}
-			if (sb.length() > 0) {
-				sb.append(", ");
-			}
-			sb.append(v);
-		}
-		return sb.toString();
-	}
-
 	private String observationValue(JsonNode obs) {
 		JsonNode q = obs.path("valueQuantity");
 		if (!q.isMissingNode() && q.has("value")) {
@@ -339,6 +458,15 @@ public class IpsHtmlRenderer {
 		if (obs.has("valueBoolean")) {
 			return obs.path("valueBoolean").asText("");
 		}
+		if (obs.has("valueDateTime")) {
+			return dateFr(obs.path("valueDateTime").asText(""));
+		}
+		if (obs.has("valueDate")) {
+			return dateFr(obs.path("valueDate").asText(""));
+		}
+		if (obs.has("valueInteger")) {
+			return obs.path("valueInteger").asText("");
+		}
 		if (obs.path("component").isArray() && obs.path("component").size() > 0) {
 			StringBuilder sb = new StringBuilder();
 			for (JsonNode c : obs.path("component")) {
@@ -352,16 +480,28 @@ public class IpsHtmlRenderer {
 		return "";
 	}
 
-	private String dosageRoute(JsonNode med) {
-		JsonNode dosage = med.path("dosage");
-		if (dosage.isArray() && dosage.size() > 0) {
-			return codeable(dosage.get(0).path("route"));
+	/** The reason the medication was given (e.g. the treated condition). */
+	private String reason(JsonNode med) {
+		JsonNode reasons = med.path("reasonCode");
+		if (reasons.isArray() && reasons.size() > 0) {
+			StringBuilder sb = new StringBuilder();
+			for (JsonNode rc : reasons) {
+				String v = codeable(rc);
+				if (v.isEmpty()) {
+					continue;
+				}
+				if (sb.length() > 0) {
+					sb.append(", ");
+				}
+				sb.append(v);
+			}
+			return sb.toString();
 		}
 		return "";
 	}
 
-	/** Compact dose+frequency summary from dosage[0], best-effort. */
-	private String dosageText(JsonNode med) {
+	/** Dosage (humanized text + route when present) in one cell. */
+	private String dosageSummary(JsonNode med) {
 		JsonNode dosage = med.path("dosage");
 		if (!dosage.isArray() || dosage.size() == 0) {
 			return "";
@@ -380,23 +520,72 @@ public class IpsHtmlRenderer {
 			sb.append(repeat.path("frequency").asText("")).append("x/").append(repeat.path("period").asText(""))
 			        .append(repeat.path("periodUnit").asText(""));
 		}
-		String txt = d.path("text").asText("");
-		if (sb.length() == 0 && !txt.isEmpty()) {
-			return txt;
+		String out = sb.toString().trim();
+		if (out.isEmpty()) {
+			out = humanizeDosageText(d.path("text").asText(""));
 		}
-		return sb.toString().trim();
+		String route = codeable(d.path("route"));
+		if (!route.isEmpty()) {
+			out = out.isEmpty() ? route : out + " · " + route;
+		}
+		return out;
+	}
+
+	/**
+	 * The pipeline emits raw dosage strings like {@code 600mg | 60 day(s)}. Translate the English
+	 * duration units, space out metric units and join the parts readably; unknown formats pass
+	 * through unchanged.
+	 */
+	private String humanizeDosageText(String raw) {
+		if (raw == null || raw.trim().isEmpty()) {
+			return "";
+		}
+		String[] parts = raw.split("\\|");
+		StringBuilder sb = new StringBuilder();
+		for (String part : parts) {
+			String p = part.trim();
+			if (p.isEmpty()) {
+				continue;
+			}
+			p = p.replace("day(s)", "jour(s)").replace("week(s)", "semaine(s)").replace("month(s)", "mois")
+			        .replace("year(s)", "an(s)");
+			p = p.replaceAll("(?i)(\\d)(mg|mcg|ml|g)\\b", "$1 $2");
+			if (sb.length() > 0) {
+				sb.append(" · ");
+			}
+			sb.append(p);
+		}
+		return sb.toString();
+	}
+
+	private String encounterTypeText(JsonNode enc) {
+		JsonNode types = enc.path("type");
+		if (types.isArray() && types.size() > 0) {
+			return codeable(types.get(0));
+		}
+		return "";
 	}
 
 	private String encounterType(JsonNode enc) {
-		JsonNode types = enc.path("type");
-		if (types.isArray() && types.size() > 0) {
-			String t = codeable(types.get(0));
-			if (!t.isEmpty()) {
-				return t;
-			}
+		String t = encounterTypeText(enc);
+		if (!t.isEmpty()) {
+			return t;
 		}
-		String cls = enc.path("class").path("display").asText("");
-		return !cls.isEmpty() ? cls : enc.path("class").path("code").asText("");
+		String cls = enc.path("class").path("code").asText("");
+		if (cls.equalsIgnoreCase("AMB")) {
+			return "Ambulatoire / Ambulatory";
+		}
+		if (cls.equalsIgnoreCase("IMP")) {
+			return "Hospitalisation / Inpatient";
+		}
+		if (cls.equalsIgnoreCase("EMER")) {
+			return "Urgence / Emergency";
+		}
+		if (cls.equalsIgnoreCase("HH")) {
+			return "Domicile / Home";
+		}
+		String display = enc.path("class").path("display").asText("");
+		return !display.isEmpty() ? display : cls;
 	}
 
 	private JsonNode bestNode(JsonNode parent, String... fields) {
@@ -418,11 +607,15 @@ public class IpsHtmlRenderer {
 		return "";
 	}
 
-	private String dateShort(String d) {
+	/** ISO date(-time) -> DD/MM/YYYY; non-conforming values pass through unchanged. */
+	private String dateFr(String d) {
 		if (d == null || d.isEmpty()) {
 			return "";
 		}
-		return d.length() >= 10 ? d.substring(0, 10) : d;
+		if (d.length() >= 10 && d.charAt(4) == '-' && d.charAt(7) == '-') {
+			return d.substring(8, 10) + "/" + d.substring(5, 7) + "/" + d.substring(0, 4);
+		}
+		return d;
 	}
 
 	// --- HTML helpers ----------------------------------------------------------------------------
@@ -459,28 +652,6 @@ public class IpsHtmlRenderer {
 	}
 
 	private String styleBlock() {
-		return "<style>"
-		        + ".ips-card{background:#fff;border-radius:12px;box-shadow:0 3px 3px -4px rgba(0,0,0,.35);"
-		        + "border-top:5px solid #566a8b;padding:24px 28px;margin-top:16px;"
-		        + "font-family:Inter,system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial;color:#0f172a;}"
-		        + ".ips-card h2{margin-top:0;font-size:20px;color:#0f172a;}"
-		        + ".ips-card h3{font-size:16px;color:#586674;margin:22px 0 8px;}"
-		        + ".ips-card .en{color:#8a94a6;font-weight:400;font-size:.9em;}"
-		        + ".ips-card .ips-patient{font-size:18px;font-weight:700;margin:4px 0 0;}"
-		        + ".ips-card .ips-sub{color:#586674;margin:2px 0 0;}"
-		        + ".ips-card .ips-ids{margin:10px 0 0;}"
-		        + ".ips-card .ips-ident{margin:2px 0;color:#1f3a5f;}"
-		        + ".ips-card .ips-pending{color:#9aa4b2;font-style:italic;}"
-		        + ".ips-card table.ips-table{width:100%;border-collapse:collapse;margin-top:6px;font-size:14px;}"
-		        + ".ips-card table.ips-table th{text-align:left;background:#eef3f9;color:#1f3a5f;padding:9px 10px;"
-		        + "border-bottom:2px solid #d3e0ef;font-weight:600;font-size:12.5px;}"
-		        + ".ips-card table.ips-table td{padding:9px 10px;border-bottom:1px solid #eef1f4;vertical-align:top;}"
-		        + ".ips-card table.ips-table tr:nth-child(even) td{background:#fafbfc;}"
-		        + ".ips-card .ips-tag{display:inline-block;padding:2px 10px;border-radius:999px;font-size:12px;font-weight:600;white-space:nowrap;}"
-		        + ".ips-card .ips-tag-red{background:#ffd7d9;color:#a2191f;}"
-		        + ".ips-card .ips-tag-green{background:#a7f0ba;color:#0e6027;}"
-		        + ".ips-card .ips-tag-blue{background:#d0e2ff;color:#0043ce;}"
-		        + ".ips-card .table-wrap{overflow-x:auto;}"
-		        + "</style>";
+		return "";
 	}
 }

--- a/api/src/test/java/org/openmrs/module/ips/fetch/IpsPatientMatcherTest.java
+++ b/api/src/test/java/org/openmrs/module/ips/fetch/IpsPatientMatcherTest.java
@@ -1,0 +1,131 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.ips.fetch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * The bundles used here mirror the real SEDISH SHR response shape: {@code entry[]} items are the
+ * resources themselves (no {@code resource} wrapper), the patient carries a
+ * {@code http://sedish-haiti.org/fhir/source-key} identifier, and names/birthdates come from the
+ * OpenCR golden record.
+ */
+public class IpsPatientMatcherTest {
+
+	private static final String SOURCE_KEY_SYSTEM = "http://sedish-haiti.org/fhir/source-key";
+
+	/** A bundle shaped like the live SHR one: entries are bare resources. */
+	private static String bundle(String... patientJsons) {
+		StringBuilder sb = new StringBuilder("{\"resourceType\":\"Bundle\",\"type\":\"document\",\"entry\":["
+		        + "{\"resourceType\":\"Composition\",\"title\":\"International Patient Summary\"}");
+		for (String p : patientJsons) {
+			sb.append(",").append(p);
+		}
+		return sb.append("]}").toString();
+	}
+
+	private static String patient(String family, String birthDate, String sourceKeyValue) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("{\"resourceType\":\"Patient\",\"id\":\"x\",");
+		sb.append("\"name\":[{\"use\":\"official\",\"text\":\"America ").append(family).append("\",");
+		sb.append("\"family\":\"").append(family).append("\",\"given\":[\"America\"]}],");
+		sb.append("\"birthDate\":\"").append(birthDate).append("\",");
+		sb.append("\"identifier\":[");
+		sb.append("{\"type\":{\"text\":\"Code National\"},\"system\":\"http://isanteplus.org/openmrs/fhir2/5-code-national\",\"value\":\"CA0201P\"}");
+		if (sourceKeyValue != null) {
+			sb.append(",{\"type\":{\"text\":\"SEDISH Source Key\"},\"system\":\"").append(SOURCE_KEY_SYSTEM);
+			sb.append("\",\"value\":\"").append(sourceKeyValue).append("\"}");
+		}
+		sb.append("]}");
+		return sb.toString();
+	}
+
+	// --- source-key match -------------------------------------------------------------------------
+
+	@Test
+	public void matches_shouldAcceptWhenTheBundlePatientCarriesTheExpectedSourceKey() {
+		String json = bundle(patient("Captain", "2001-02-17", "54111-35"));
+		assertTrue(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "1990-01-01", "SomeoneElse"));
+	}
+
+	@Test
+	public void matches_shouldRejectWhenSourceKeyAndDemographicsBothDiffer() {
+		// the exact wrong-patient scenario seen on the test SHR: asked for one patient,
+		// got another site's patient back
+		String json = bundle(patient("Avi", "2026-07-09", "73106-34"));
+		assertFalse(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "Captain"));
+	}
+
+	// --- demographic fallback (no source-key on the golden record) --------------------------------
+
+	@Test
+	public void matches_shouldAcceptOnBirthDateAndFamilyNameWhenNoSourceKeyIsPresent() {
+		String json = bundle(patient("Captain", "2001-02-17", null));
+		assertTrue(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "Captain"));
+	}
+
+	@Test
+	public void matches_shouldCompareFamilyNamesCaseInsensitively() {
+		String json = bundle(patient("CAPTAIN", "2001-02-17", null));
+		assertTrue(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "captain"));
+	}
+
+	@Test
+	public void matches_shouldRejectWhenOnlyTheBirthDateMatches() {
+		String json = bundle(patient("Avi", "2001-02-17", null));
+		assertFalse(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "Captain"));
+	}
+
+	@Test
+	public void matches_shouldRejectWhenOnlyTheFamilyNameMatches() {
+		String json = bundle(patient("Captain", "2026-07-09", null));
+		assertFalse(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "Captain"));
+	}
+
+	// --- robustness -------------------------------------------------------------------------------
+
+	@Test
+	public void matches_shouldRejectWhenTheBundleHasNoPatientResource() {
+		String json = "{\"resourceType\":\"Bundle\",\"entry\":[{\"resourceType\":\"Composition\"}]}";
+		assertFalse(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "Captain"));
+	}
+
+	@Test
+	public void matches_shouldRejectUnparseableJson() {
+		assertFalse(IpsPatientMatcher.matches("not json", SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "Captain"));
+	}
+
+	@Test
+	public void matches_shouldAlsoHandleStandardFhirBundlesWithResourceWrappedEntries() {
+		String json = "{\"resourceType\":\"Bundle\",\"entry\":[{\"resource\":"
+		        + patient("Captain", "2001-02-17", "54111-35") + "}]}";
+		assertTrue(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "1990-01-01", "SomeoneElse"));
+	}
+
+	@Test
+	public void matches_shouldCheckEveryPatientOfACrossFacilityBundleNotJustTheFirst() {
+		// A cross-facility bundle carries the golden record AND every linked source record, in
+		// arbitrary order. Our own record (carrying our source-key) may not come first — the guard
+		// must scan them all before rejecting.
+		String otherSiteRecord = patient("Kaptenn", "2001-02-17", "73106-59");
+		String ourRecord = patient("Captain", "2001-02-17", "54111-35");
+		String json = bundle(otherSiteRecord, ourRecord);
+		assertTrue(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "1990-01-01", "SomeoneElse"));
+	}
+
+	@Test
+	public void matches_shouldStillRejectWhenNoPatientOfTheBundleMatches() {
+		String json = bundle(patient("Avi", "2026-07-09", "73106-34"), patient("Kaptenn", "1999-05-05", "73106-59"));
+		assertFalse(IpsPatientMatcher.matches(json, SOURCE_KEY_SYSTEM, "54111-35", "2001-02-17", "Captain"));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/ips/fetch/SourceKeyTest.java
+++ b/api/src/test/java/org/openmrs/module/ips/fetch/SourceKeyTest.java
@@ -1,0 +1,62 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.ips.fetch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class SourceKeyTest {
+
+	// --- build(msppCode, patientId) ---------------------------------------------------------------
+
+	@Test
+	public void build_shouldConcatenateMsppCodeAndPatientId() {
+		assertEquals("54111-35", SourceKey.build("54111", 35));
+	}
+
+	@Test
+	public void build_shouldTrimTheMsppCode() {
+		assertEquals("54111-35", SourceKey.build(" 54111 ", 35));
+	}
+
+	@Test
+	public void build_shouldReturnNullWhenMsppCodeIsMissing() {
+		assertNull(SourceKey.build(null, 35));
+		assertNull(SourceKey.build("", 35));
+		assertNull(SourceKey.build("   ", 35));
+	}
+
+	@Test
+	public void build_shouldReturnNullWhenPatientIdIsMissing() {
+		assertNull(SourceKey.build("54111", null));
+	}
+
+	// --- buildFetchUrl(base, sourceKey, isantePlusId) ---------------------------------------------
+
+	@Test
+	public void buildFetchUrl_shouldUseSourceKeyPathWhenSourceKeyIsPresent() {
+		assertEquals("https://shr/SHR/ips/Patient/source-key/54111-35",
+		    SourceKey.buildFetchUrl("https://shr/SHR/ips", "54111-35", "1001PD"));
+	}
+
+	@Test
+	public void buildFetchUrl_shouldFallBackToIsantePlusPathWhenSourceKeyIsAbsent() {
+		assertEquals("https://shr/SHR/ips/Patient/isanteplus/1001PD",
+		    SourceKey.buildFetchUrl("https://shr/SHR/ips", null, "1001PD"));
+	}
+
+	@Test
+	public void buildFetchUrl_shouldStripTheTrailingSlashOfTheBaseUrl() {
+		assertEquals("https://shr/SHR/ips/Patient/source-key/54111-35",
+		    SourceKey.buildFetchUrl("https://shr/SHR/ips/", "54111-35", "1001PD"));
+	}
+}

--- a/api/src/test/java/org/openmrs/module/ips/render/IpsHtmlRendererTest.java
+++ b/api/src/test/java/org/openmrs/module/ips/render/IpsHtmlRendererTest.java
@@ -1,0 +1,204 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.ips.render;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * The test bundle mirrors the live SEDISH SHR shape: bare-resource entries, each clinical
+ * resource tagged with its facility ({@code http://sedish-haiti.org/fhir/mspp-site}), and field
+ * patterns copied from real patients (1001PD / 1000PE).
+ */
+public class IpsHtmlRendererTest {
+
+	private static final String SITE_TAG_HELENE = "{\"system\":\"http://sedish-haiti.org/fhir/mspp-site\",\"code\":\"73106\",\"display\":\"Ste Hélène\"}";
+
+	private static final String SITE_TAG_ANNE = "{\"system\":\"http://sedish-haiti.org/fhir/mspp-site\",\"code\":\"75101\",\"display\":\"Ste Anne\"}";
+
+	private final IpsHtmlRenderer renderer = new IpsHtmlRenderer();
+
+	private static String bundle(String... resources) {
+		StringBuilder sb = new StringBuilder("{\"resourceType\":\"Bundle\",\"type\":\"document\",\"entry\":[");
+		for (int i = 0; i < resources.length; i++) {
+			if (i > 0) {
+				sb.append(",");
+			}
+			sb.append(resources[i]);
+		}
+		return sb.append("]}").toString();
+	}
+
+	private static String patient() {
+		return "{\"resourceType\":\"Patient\",\"id\":\"p1\",\"gender\":\"male\",\"birthDate\":\"2001-02-17\","
+		        + "\"name\":[{\"text\":\"America Captain\",\"family\":\"Captain\",\"given\":[\"America\"]}],"
+		        + "\"identifier\":["
+		        + "{\"type\":{\"text\":\"iSantePlus ID\"},\"system\":\"http://isanteplus.org/openmrs/fhir2/3-isanteplus-id\",\"value\":\"1001PD\"},"
+		        + "{\"type\":{\"text\":\"SEDISH Source Key\"},\"system\":\"http://sedish-haiti.org/fhir/source-key\",\"value\":\"73106-59\"},"
+		        + "{\"type\":{\"text\":\"OpenMRS UUID\"},\"system\":\"urn:x\",\"value\":\"5bd9eabe-dbea-48d2-9b8b-471941f044bd\"}"
+		        + "]}";
+	}
+
+	private static String medication(String siteTag) {
+		return "{\"resourceType\":\"MedicationStatement\",\"status\":\"active\","
+		        + "\"meta\":{\"tag\":[" + siteTag + "]},"
+		        + "\"medicationCodeableConcept\":{\"text\":\"ABACAVIR\"},"
+		        + "\"effectiveDateTime\":\"2026-07-24T16:55:00\","
+		        + "\"reasonCode\":[{\"coding\":[{\"display\":\"HUMAN IMMUNODEFICIENCY VIRUS (HIV) DISEASE\"}]}],"
+		        + "\"dosage\":[{\"text\":\"600mg | 60 day(s)\"}]}";
+	}
+
+	private static String encounter(String type, String status, String date, String siteTag, String extraTag) {
+		StringBuilder sb = new StringBuilder("{\"resourceType\":\"Encounter\",\"status\":\"").append(status)
+		        .append("\",\"class\":{\"system\":\"http://terminology.hl7.org/CodeSystem/v3-ActCode\",\"code\":\"AMB\"},");
+		sb.append("\"meta\":{\"tag\":[").append(siteTag);
+		if (extraTag != null) {
+			sb.append(",").append(extraTag);
+		}
+		sb.append("]},");
+		if (type != null) {
+			sb.append("\"type\":[{\"text\":\"").append(type).append("\"}],");
+		}
+		sb.append("\"period\":{\"start\":\"").append(date).append("\"}}");
+		return sb.toString();
+	}
+
+	private static String dateObservation(String siteTag) {
+		return "{\"resourceType\":\"Observation\",\"status\":\"final\","
+		        + "\"meta\":{\"tag\":[" + siteTag + "]},"
+		        + "\"category\":[{\"coding\":[{\"code\":\"exam\"}]}],"
+		        + "\"code\":{\"text\":\"Date medication refills due\"},"
+		        + "\"effectiveDateTime\":\"2026-07-24T16:55:00\",\"valueDateTime\":\"2026-09-23T00:00:00\"}";
+	}
+
+	private static String immunization(String vaccine, String date, String siteTag) {
+		return "{\"resourceType\":\"Immunization\",\"status\":\"completed\","
+		        + "\"meta\":{\"tag\":[" + siteTag + "]},"
+		        + "\"vaccineCode\":{\"text\":\"" + vaccine + "\"},"
+		        + "\"occurrenceDateTime\":\"" + date + "\"}";
+	}
+
+	// --- site attribution -------------------------------------------------------------------------
+
+	@Test
+	public void render_shouldShowTheSiteNameOnEachClinicalRow() {
+		String html = renderer.render(bundle(patient(), medication(SITE_TAG_HELENE)));
+		assertTrue(html.contains("Site"));
+		assertTrue(html.contains("Ste Hélène"));
+	}
+
+	@Test
+	public void render_shouldListAllSitesInThePatientHeader() {
+		String html = renderer.render(bundle(patient(), medication(SITE_TAG_HELENE),
+		    encounter("Ord. Médicale", "finished", "2026-07-10T04:52:30", SITE_TAG_ANNE, null)));
+		assertTrue(html.contains("Sites"));
+		assertTrue(html.indexOf("Ste Anne") > 0);
+		assertTrue(html.indexOf("Ste Hélène") > 0);
+	}
+
+	// --- noise filtering --------------------------------------------------------------------------
+
+	@Test
+	public void render_shouldDropRegistrationEncounters() {
+		String html = renderer.render(bundle(patient(),
+		    encounter("Enregistrement de patient", "finished", "2026-07-10T04:52:30", SITE_TAG_HELENE, null)));
+		assertFalse(html.contains("Enregistrement de patient"));
+	}
+
+	@Test
+	public void render_shouldDropVisitContainerEncounters() {
+		String visitTag = "{\"system\":\"http://x/encounter-tag\",\"code\":\"visit\",\"display\":\"Visit\"}";
+		String html = renderer.render(bundle(patient(),
+		    encounter(null, "in-progress", "2026-07-24T16:46:54", SITE_TAG_HELENE, visitTag)));
+		assertFalse(html.contains("Consultations"));
+	}
+
+	@Test
+	public void render_shouldDropUntypedUnfinishedEncounters() {
+		String html = renderer.render(bundle(patient(),
+		    encounter(null, "in-progress", "2026-07-24T16:46:54", SITE_TAG_HELENE, null)));
+		assertFalse(html.contains("Consultations"));
+	}
+
+	@Test
+	public void render_shouldHideTechnicalIdentifiersInTheHeader() {
+		String html = renderer.render(bundle(patient()));
+		assertTrue(html.contains("1001PD"));
+		assertFalse(html.contains("SEDISH Source Key"));
+		assertFalse(html.contains("5bd9eabe-dbea-48d2-9b8b-471941f044bd"));
+	}
+
+	@Test
+	public void render_shouldNotShowCategoryColumns() {
+		String html = renderer.render(bundle(patient(), dateObservation(SITE_TAG_HELENE)));
+		assertFalse(html.contains("Catégorie"));
+		assertFalse(html.contains(">exam<"));
+	}
+
+	@Test
+	public void render_shouldHideNominalStatusesButKeepInformativeOnes() {
+		String html = renderer.render(bundle(patient(),
+		    encounter("Ord. Médicale", "finished", "2026-07-24T16:55:00", SITE_TAG_HELENE, null),
+		    medication(SITE_TAG_HELENE)));
+		// finished encounter: no pill
+		assertFalse(html.contains(">finished<"));
+		// active medication: pill kept
+		assertTrue(html.contains(">active<"));
+	}
+
+	// --- completeness / readability ---------------------------------------------------------------
+
+	@Test
+	public void render_shouldShowDateValuedObservations() {
+		String html = renderer.render(bundle(patient(), dateObservation(SITE_TAG_HELENE)));
+		assertTrue(html.contains("23/09/2026"));
+	}
+
+	@Test
+	public void render_shouldShowTheMedicationReason() {
+		String html = renderer.render(bundle(patient(), medication(SITE_TAG_HELENE)));
+		assertTrue(html.contains("Motif"));
+		assertTrue(html.contains("HUMAN IMMUNODEFICIENCY VIRUS (HIV) DISEASE"));
+	}
+
+	@Test
+	public void render_shouldFallBackToTheTranslatedClassForUntypedFinishedEncounters() {
+		String html = renderer.render(bundle(patient(),
+		    encounter(null, "finished", "2026-07-24T16:55:00", SITE_TAG_HELENE, null)));
+		assertTrue(html.contains("Ambulatoire"));
+	}
+
+	@Test
+	public void render_shouldHumanizeTheDosageText() {
+		String html = renderer.render(bundle(patient(), medication(SITE_TAG_HELENE)));
+		assertTrue(html.contains("600 mg · 60 jour(s)"));
+		assertFalse(html.contains("600mg | 60 day(s)"));
+	}
+
+	@Test
+	public void render_shouldFormatDatesAsDayMonthYear() {
+		String html = renderer.render(bundle(patient(), medication(SITE_TAG_HELENE)));
+		assertTrue(html.contains("24/07/2026"));
+		assertFalse(html.contains("2026-07-24"));
+	}
+
+	@Test
+	public void render_shouldSortRowsByDateDescending() {
+		String html = renderer.render(bundle(patient(),
+		    immunization("POLIO VACCINATION, ORAL", "2025-01-01T00:00:00", SITE_TAG_HELENE),
+		    immunization("Moderna COVID-19 vaccine", "2026-07-22T16:06:49", SITE_TAG_HELENE)));
+		int newer = html.indexOf("Moderna COVID-19 vaccine");
+		int older = html.indexOf("POLIO VACCINATION, ORAL");
+		assertTrue(newer > 0 && older > 0);
+		assertTrue(newer < older);
+	}
+}


### PR DESCRIPTION
Brings the IPS-fetch hardening and renderer work (developed in the iSantePlus deployment) back to `1.x`. Filtered to the **module** changes only — deployment-specific artifacts (the SHR mediator patch package, internal notes/specs, and the site-specific DEPLOY.md) were intentionally left out.

### What it adds
- **Source-key lookup (wrong-patient safety).** iSantePlus IDs are issued per facility and are **not** nationally unique, so fetching an IPS by iSantePlus ID can return a *different* patient's summary. When the site's MSPP code is configured (GP `mpi-client.source.mspp`, shared with the mpi-client module), the module now fetches by the nationally-unique **source-key** `<mspp>-<patient_id>` at `/Patient/source-key/<key>`; otherwise it falls back to the legacy iSantePlus-ID path. New `fetch/SourceKey`.
- **`IpsPatientMatcher` guard.** Before storing or showing a bundle, it verifies the returned Patient really is the local patient (source-key identifier, else birth date + family name). A non-matching bundle is never stored and never displayed; a previously-stored mismatch is ignored and refetched.
- **Renderer overhaul.** Per-type structured columns + per-site column, humanized dosage/medication reason, date-valued observations, DD/MM/YYYY dates, newest-first; drops registration/visit-container encounters and technical/nominal noise.
- **Tests.** 32 unit tests across `SourceKey`, `IpsPatientMatcher`, and the renderer. `mvn clean package` (JDK 8) green.

### Notes for maintainers
- The source-key system default (`DEFAULT_SOURCE_KEY_SYSTEM`) is SEDISH's; it's overridable via `mpi-client.source.keySystem`. Happy to blank it / make it required if you'd prefer no deployment-specific default.
- The source-key route (`GET /Patient/source-key/:key`) must be exposed by the SHR mediator; that mediator change lives in shared-health-record, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)